### PR TITLE
Hard wrap breaks link to "Using a module" guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ version 2.1403.17
 
 [![gitTio](http://gitt.io/badge.png)](http://gitt.io/component/com.featherdirect.ticomscore)
 
-Download the latest distribution ZIP-file and consult the [Titanium Documentation](http://
-docs.appcelerator.com/titanium/latest/#!/guide/Using_a_Module) on how install it, or simply use the 
+Download the latest distribution ZIP-file and consult the [Titanium Documentation](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_a_Module) on how
+install it, or simply use the 
 [gitTio CLI](http://gitt.io/cli):
 
 `$ gittio install com.featherdirect.ticomscore`


### PR DESCRIPTION
The link to the Titanium "Using a module" guide was broken because
of the linebreak in between the `http://` and the `docs.appcelerator.com/titanium/latest/#!/guide/Using_a_Module`
parts of the URL
